### PR TITLE
Bump decimal from 1.8.1 to 2.0.0 and use new compare

### DIFF
--- a/lib/enumerati.ex
+++ b/lib/enumerati.ex
@@ -51,9 +51,9 @@ defmodule Enumerati do
     end)
   end
 
-  defp lte(%Decimal{} = av, %Decimal{} = bv), do: Decimal.cmp(av, bv) != :gt
+  defp lte(%Decimal{} = av, %Decimal{} = bv), do: Decimal.compare(av, bv) != :gt
   defp lte(av, bv), do: av <= bv
 
-  defp gte(%Decimal{} = av, %Decimal{} = bv), do: Decimal.cmp(av, bv) != :lt
+  defp gte(%Decimal{} = av, %Decimal{} = bv), do: Decimal.compare(av, bv) != :lt
   defp gte(av, bv), do: av >= bv
 end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Enumerati.MixProject do
 
   defp deps do
     [
-      {:decimal, "~> 1.6"},
+      {:decimal, "~> 2.0"},
       {:dialyxir, "~> 1.0.0-rc.7", only: :dev, runtime: false},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:ex_unit_notifier, "~> 0.1", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm", "3cb154b00225ac687f6cbd4acc4b7960027c757a5152b369923ead9ddbca7aec"},
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.7", "6287f8f2cb45df8584317a4be1075b8c9b8a69de8eeb82b4d9e6c761cf2664cd", [:mix], [{:erlex, ">= 0.2.5", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "506294d6c543e4e5282d4852aead19ace8a35bedeb043f9256a06a6336827122"},
   "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},


### PR DESCRIPTION
`.cmp` is deprecated and need to use `.compare` instead.